### PR TITLE
parsing: allow parsing directly from a file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 changelog-utils-*.tgz
 node_modules
 out/
+tests/.*.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## unreleased
+
+### Added
+
+- Option to parse directly from file (`string` or `{ file: string }` source)
+
 ## 0.0.1
 
 ### Fixed

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { readFileSync } from 'fs';
 import parse from '.';
 import { formatChangelog } from './formatter';
 import androidStringResourceFormatter from './formatters/android-string-resource';
@@ -25,8 +24,7 @@ function selectFormatter(param: string) {
 const filename = process.argv[2];
 const formatter = selectFormatter(process.argv[3]);
 
-const contents = readFileSync(filename);
-parse(contents.toString())
+parse({ file: filename })
   .then((parsed) => {
     process.stdout.write(formatChangelog(parsed, formatter));
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,10 +3,25 @@ import semver from 'semver';
 import { IParsedChangelog } from './types';
 import mapReleaseDetails from './mapping';
 
-export default async function parse(content: string): Promise<IParsedChangelog> {
-  const parsed = await changelogParser({
-    text: content,
-  });
+interface IFileSource {
+  file: string;
+}
+
+type ParseSource = string | IFileSource;
+
+export default async function parse(source: ParseSource): Promise<IParsedChangelog> {
+  function parseSource() {
+    if (typeof source === 'string') {
+      return changelogParser({
+        text: source,
+      });
+    }
+
+    return changelogParser({
+      filePath: source.file,
+    });
+  }
+  const parsed = await parseSource();
 
   const indexOfLatest = parsed.versions
     .findIndex((v: { version: string | null }) => v.version !== null);

--- a/tests/parsing.ts
+++ b/tests/parsing.ts
@@ -1,3 +1,4 @@
+import { writeFileSync } from 'fs';
 import { expect } from 'chai';
 import parseChangelog from '../src';
 import basicChangelog, { singleEntry, withUnreleased } from './data';
@@ -9,6 +10,21 @@ describe('can parse changelog into details', () => {
     expect(last.parsed.Added).to.eql(['A']);
     expect(last.parsed.Removed).to.eql(['B']);
     expect(last.date).to.eql('2023-01-01');
+  });
+
+  describe('parse from file', () => {
+    const testFile = 'tests/.basic-changelog.md';
+
+    before('write test file', () => {
+      writeFileSync(testFile, basicChangelog);
+    });
+
+    it('parses the same as text', async () => {
+      const parsedFromString = await parseChangelog(basicChangelog);
+      const parsedFromFile = await parseChangelog({ file: testFile });
+
+      expect(parsedFromFile).to.eqls(parsedFromString);
+    });
   });
 
   it('multiple versions', async () => {


### PR DESCRIPTION
add `ParseSource` union type of `string` and an object with only a file name. map this to `changelogParser`'s `filePath` object (or `text` for string as before)

use this in cli instead of `readFileSync`