### PR TITLE
fix: reject on file errors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import changelogParser from 'changelog-parser';
+import { readFileSync } from 'fs';
 import semver from 'semver';
 import { IParsedChangelog } from './types';
 import mapReleaseDetails from './mapping';
@@ -17,8 +18,9 @@ export default async function parse(source: ParseSource): Promise<IParsedChangel
       });
     }
 
+    const content = readFileSync(source.file);
     return changelogParser({
-      filePath: source.file,
+      text: content.toString(),
     });
   }
   const parsed = await parseSource();

--- a/tests/parsing.ts
+++ b/tests/parsing.ts
@@ -25,6 +25,16 @@ describe('can parse changelog into details', () => {
 
       expect(parsedFromFile).to.eqls(parsedFromString);
     });
+
+    it('fails by rejecting promise', async () => {
+      let caughtError = false;
+      try {
+        await parseChangelog({ file: 'non-existing-file' });
+      } catch (e) {
+        caughtError = true;
+      }
+      expect(caughtError).to.eql(true);
+    });
   });
 
   it('multiple versions', async () => {


### PR DESCRIPTION
read the file using `fs` and pass the text content into `changelog`. this is needed because file errors are not handled via callbacks/promises rejectios from changelog/line-reader