### PR TITLE
add commander for cli parsing

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,5 @@ jobs:
     - run: npm run tsc
     - run: npm test
     - run: npm run lint
+    - name: test cli
+      run: ./tests/cli.sh

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 ### Added
 
 - Option to parse directly from file (`string` or `{ file: string }` source)
+- CLI argument parsing and error handling
+- `commander` dependency for cli argument parsing
 
 ## 0.0.1
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "changelog-parser": "^3.0.1",
+        "commander": "^11.1.0",
         "semver": "^7.5.4"
       },
       "bin": {
@@ -836,6 +837,14 @@
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true
+    },
+    "node_modules/commander": {
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-11.1.0.tgz",
+      "integrity": "sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==",
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
   "license": "MIT",
   "dependencies": {
     "changelog-parser": "^3.0.1",
+    "commander": "^11.1.0",
     "semver": "^7.5.4"
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -29,7 +29,10 @@ program
   .version('0.0.1');
 
 program
-  .command('format <CHANGELOG-file> [format]', { isDefault: true })
+  .command('format', { isDefault: true })
+  .description('Formats a changelog using a specified formatter')
+  .argument('<CHANGELOG-file>', 'the changelog file to parse')
+  .argument('[format]', 'the formatter used to print the changelog')
   .action(async (file: string, format: string) => {
     const formatter = selectFormatter(format);
     const parsed = await parse({ file });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -24,6 +24,11 @@ function selectFormatter(param: string) {
 
 const program = new Command();
 program
+  .name('changelog-utils')
+  .description('CLI for utilities to parse changelogs and build release notes')
+  .version('0.0.1');
+
+program
   .command('format <CHANGELOG-file> [format]', { isDefault: true })
   .action(async (file: string, format: string) => {
     const formatter = selectFormatter(format);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 
+import { Command } from 'commander';
 import parse from '.';
 import { formatChangelog } from './formatter';
 import androidStringResourceFormatter from './formatters/android-string-resource';
@@ -21,10 +22,17 @@ function selectFormatter(param: string) {
   }
 }
 
-const filename = process.argv[2];
-const formatter = selectFormatter(process.argv[3]);
-
-parse({ file: filename })
-  .then((parsed) => {
+const program = new Command();
+program
+  .command('format <CHANGELOG-file> [format]', { isDefault: true })
+  .action(async (file: string, format: string) => {
+    const formatter = selectFormatter(format);
+    const parsed = await parse({ file });
     process.stdout.write(formatChangelog(parsed, formatter));
+  });
+
+program.parseAsync()
+  .catch((e) => {
+    process.stderr.write(`Error: ${e.message}\n`);
+    process.exit(1);
   });

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+cli=./out/src/cli.js
+failed=0
+
+_exec() {
+  fail=$1; shift;
+
+  $cli "$@" >/dev/null 2>&1
+  err=$?
+
+  if [ "$err" = "$fail" ] ; then
+    echo "ok $*"
+  else
+    echo "not ok $*"
+    failed=1
+  fi
+}
+
+passes() {
+  _exec 0 "$@"
+}
+fails() {
+  _exec 1 "$@"
+}
+
+# formatting
+passes CHANGELOG.md
+passes CHANGELOG.md latest
+fails CHANGELOG.md invalid-formatter
+passes format CHANGELOG.md
+passes format CHANGELOG.md latest
+fails format CHANGELOG.md invalid-formatter
+
+exit $failed

--- a/tests/cli.sh
+++ b/tests/cli.sh
@@ -24,7 +24,12 @@ fails() {
   _exec 1 "$@"
 }
 
-# formatting
+echo "auto/cli util"
+passes --help
+passes help
+passes --version
+
+echo "formatting"
 passes CHANGELOG.md
 passes CHANGELOG.md latest
 fails CHANGELOG.md invalid-formatter


### PR DESCRIPTION
add `commander` dependency. use that to parse the cli arguments, instead of using `process.argv` directly

currently only the format command (as before) and use that as default. this allows formatting with just the file name, or with `format filename` and will allow easier adding more subcommands in the future

add cli option to output the program version and exit

add a script file that calls the cli with possible cli argument options, checking if the cli exits successfully or fails when expected

