### PR TITLE
hide options for changelog output

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,7 +2,7 @@
 
 import { Command } from 'commander';
 import parse from '.';
-import { formatChangelog } from './formatter';
+import { IFormatOptions, formatChangelog } from './formatter';
 import selectFormatter from './formatters';
 
 const program = new Command();
@@ -16,8 +16,11 @@ program
   .description('Formats a changelog using a specified formatter')
   .argument('<CHANGELOG-file>', 'the changelog file to parse')
   .argument('[format]', 'the formatter used to print the changelog')
-  .action(async (file: string, format: string) => {
-    const formatter = selectFormatter(format, { showDate: true, listItemPrefix: '- ' });
+  .option('--show-date', 'include the date in () after each release number', true)
+  .option('--no-show-date')
+  .option('--list-item-prefix <characters>', 'characters to include before each list item', '- ')
+  .action(async (file: string, format: string, options: IFormatOptions) => {
+    const formatter = selectFormatter(format, options);
     const parsed = await parse({ file });
     process.stdout.write(formatChangelog(parsed, formatter));
   });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ program
   .argument('<CHANGELOG-file>', 'the changelog file to parse')
   .argument('[format]', 'the formatter used to print the changelog')
   .action(async (file: string, format: string) => {
-    const formatter = selectFormatter(format);
+    const formatter = selectFormatter(format, { showDate: true, listItemPrefix: '- ' });
     const parsed = await parse({ file });
     process.stdout.write(formatChangelog(parsed, formatter));
   });

--- a/src/formatter.ts
+++ b/src/formatter.ts
@@ -8,6 +8,11 @@ export interface IFormatter {
   includeRelease? (release: IParsedRelease): boolean;
 }
 
+export interface IFormatOptions {
+  showDate: boolean;
+  listItemPrefix: string;
+}
+
 export function formatChangelog(changelog: IParsedChangelog, formatter: IFormatter): string {
   const includeRelease = formatter.includeRelease || (() => true);
 

--- a/src/formatters/android-string-resource.ts
+++ b/src/formatters/android-string-resource.ts
@@ -1,7 +1,7 @@
-import { IFormatter } from '../formatter';
+import { IFormatOptions, IFormatter } from '../formatter';
 import plainTextFormatter from './plain-text';
 
-export default function androidStringResourceFormatter(): IFormatter {
+export default function androidStringResourceFormatter(options: IFormatOptions): IFormatter {
   return {
     header: `<?xml version="1.0" encoding="utf-8"?>
 <resources>
@@ -9,6 +9,6 @@ export default function androidStringResourceFormatter(): IFormatter {
 `,
     footer: `"</string>
 </resources>`,
-    format: plainTextFormatter().format,
+    format: plainTextFormatter(options).format,
   };
 }

--- a/src/formatters/index.ts
+++ b/src/formatters/index.ts
@@ -1,17 +1,18 @@
+import { IFormatOptions } from '../formatter';
 import androidStringResourceFormatter from './android-string-resource';
 import latestReleaseFormatter from './latest';
 import plainTextFormatter from './plain-text';
 
-export default function selectFormatter(name: string | undefined) {
+export default function selectFormatter(name: string | undefined, options: IFormatOptions) {
   switch (name) {
     case undefined:
-      return plainTextFormatter();
+      return plainTextFormatter(options);
     case 'text':
-      return plainTextFormatter();
+      return plainTextFormatter(options);
     case 'latest':
-      return latestReleaseFormatter();
+      return latestReleaseFormatter(options);
     case 'android-string-resource':
-      return androidStringResourceFormatter();
+      return androidStringResourceFormatter(options);
     default:
       throw new Error(`Unknown formatter ${name}`);
   }

--- a/src/formatters/latest.ts
+++ b/src/formatters/latest.ts
@@ -1,8 +1,8 @@
-import { IFormatter } from '../formatter';
+import { IFormatOptions, IFormatter } from '../formatter';
 import { IParsedRelease } from '../types';
 import plainTextFormatter from './plain-text';
 
-export default function latestReleaseFormatter(): IFormatter {
+export default function latestReleaseFormatter(options: IFormatOptions): IFormatter {
   let alreadyIncluded = false;
 
   return {
@@ -14,6 +14,6 @@ export default function latestReleaseFormatter(): IFormatter {
       alreadyIncluded = true;
       return true;
     },
-    format: plainTextFormatter().format,
+    format: plainTextFormatter(options).format,
   };
 }

--- a/src/formatters/plain-text.ts
+++ b/src/formatters/plain-text.ts
@@ -1,14 +1,15 @@
-import { IFormatter } from '../formatter';
+import { IFormatOptions, IFormatter } from '../formatter';
 import { IParsedRelease } from '../types';
 
-function mapChanges(prefix: string, items: string[]) {
-  return items.map((item: string) => `- ${prefix}: ${item}`);
-}
+export default function plainTextFormatter(options: IFormatOptions): IFormatter {
+  function mapChanges(prefix: string, items: string[]) {
+    return items.map((item: string) => `${options.listItemPrefix}${prefix}: ${item}`);
+  }
 
-export default function plainTextFormatter(): IFormatter {
   return {
     format: (release: IParsedRelease): string => {
-      const versionInfo = `${release.version || 'unreleased'} (${release.date || 'no date'})`;
+      const dateInfo = options.showDate ? ` (${release.date || 'no date'})` : '';
+      const versionInfo = `${release.version || 'unreleased'}${dateInfo}`;
 
       const added = mapChanges('Added', release.added);
       const changed = mapChanges('Changed', release.changed);

--- a/tests/formatters.ts
+++ b/tests/formatters.ts
@@ -26,8 +26,32 @@ describe('can format changelog to string', () => {
       + '- Removed: B';
 
     it('formats in minimal output', () => {
-      const text = formatChangelog(changelog, plainTextFormatter());
+      const text = formatChangelog(changelog, plainTextFormatter({
+        showDate: true,
+        listItemPrefix: '- ',
+      }));
       expect(text).to.eql(expected);
+    });
+
+    describe('with options', () => {
+      it('without dates', () => {
+        const text = formatChangelog(changelog, plainTextFormatter({
+          showDate: false,
+          listItemPrefix: '- ',
+        }));
+        expect(text).to.not.contain('0.0.3 (2023-01-03)\n');
+        expect(text).to.contain('0.0.3\n');
+        expect(text).to.contain('0.0.2\n');
+        expect(text).to.contain('0.0.0\n');
+      });
+
+      it('with different listItemPrefix', () => {
+        const text = formatChangelog(changelog, plainTextFormatter({
+          showDate: true,
+          listItemPrefix: 'X ',
+        }));
+        expect(text).to.contain('\nX Added: A\n');
+      });
     });
   });
 


### PR DESCRIPTION
use `IFormatOptions` in plain text formatter to hide the date of a release (`showDate: false`) and change the characters before each list item in a release (`listItemPrefix: '...'`)

add `--show-date` (default)/`--no-show-date` and `--list-item-prefix` cli options